### PR TITLE
fix STF Vector JSON serialization circular reference

### DIFF
--- a/src/pages/Codec.tsx
+++ b/src/pages/Codec.tsx
@@ -1,4 +1,5 @@
 import * as bytes from "@typeberry/lib/bytes";
+import * as codec from "@typeberry/lib/codec";
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { CodecInput } from "../components/CodecInput";
@@ -72,6 +73,12 @@ export function Codec({ isDiffEnabled = false }: CodecProps) {
       const json = JSON.stringify(
         decoded,
         (_key, value) => {
+          if (value instanceof codec.ObjectView) {
+            return value.materialize();
+          }
+          if (value instanceof codec.SequenceView) {
+            return value.map((v) => v.materialize());
+          }
           if (value instanceof bytes.BytesBlob) {
             return value.toString();
           }

--- a/src/test/stf-vector-json.test.ts
+++ b/src/test/stf-vector-json.test.ts
@@ -1,0 +1,41 @@
+import * as bytes from "@typeberry/lib/bytes";
+import * as codec from "@typeberry/lib/codec";
+import { describe, expect, it } from "vitest";
+
+import { ALL_CHAIN_SPECS, kinds } from "../components/constants";
+
+const replacer = (_key: string, value: unknown) => {
+  if (value instanceof codec.ObjectView) {
+    return value.materialize();
+  }
+  if (value instanceof codec.SequenceView) {
+    return value.map((v) => v.materialize());
+  }
+  if (value instanceof bytes.BytesBlob) {
+    return value.toString();
+  }
+  if (value instanceof bytes.Bytes) {
+    return value.toString();
+  }
+  if (value instanceof Map) {
+    return Object.fromEntries(value.entries());
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+};
+
+describe("STF Vector JSON serialization regression", () => {
+  const stfVectorKind = kinds.find((k) => k.name === "STF Vector");
+  if (!stfVectorKind) throw new Error("STF Vector kind not found");
+
+  ALL_CHAIN_SPECS.forEach(({ name, spec }) => {
+    it(`decoded STF Vector is JSON-serializable (${name})`, () => {
+      const example = stfVectorKind.example(spec);
+      const encoded = stfVectorKind.encode(example, spec);
+      const decoded = stfVectorKind.decode(encoded, spec);
+      expect(() => JSON.stringify(decoded, replacer, 2)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Loading the `STF Vector` example in the codec UI threw `TypeError: Converting circular structure to JSON --> property 'View' closes the circle`.
- Root cause: `StateTransition.Codec` decodes its `block` field using `Block.Codec.View`, so the decoded object's `block` is an `ObjectView`. `ObjectView` holds `Descriptor` references, and `Descriptor.View` defaults to `this` when there's no dedicated view — a self-loop that `JSON.stringify` walks into.
- Fix: in the `JSON.stringify` replacer in `Codec.tsx`, detect `codec.ObjectView` / `codec.SequenceView` and materialize them to plain values before serialization.

## Test plan
- [x] `npm run test` — 154 passed, including the new regression test `src/test/stf-vector-json.test.ts` which encodes/decodes the STF Vector example and asserts it is JSON-serializable for both chain specs.
- [x] `npm run qa` clean.
- [x] `npm run build` clean.
- [ ] Manual: open the codec UI, select `STF Vector`, click `Example STF Vector` — JSON pane renders without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)