### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fluffy-codec-web",
       "version": "0.0.0",
       "dependencies": {
-        "@fluffylabs/shared-ui": "^0.8.1",
+        "@fluffylabs/shared-ui": "^0.8.2",
         "@typeberry/lib": "^0.5.10",
         "lucide-react": "^1.8.0",
         "react": "^19.2.4",
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@fluffylabs/shared-ui": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@fluffylabs/shared-ui/-/shared-ui-0.8.1.tgz",
-      "integrity": "sha512-lC7/3F5dL7A+ZF7v91DDYcuJHcbc48oU7Wz1oUtwgxSz2VpCOq3OWpcIr3qTqairwjy5gMLxKMdqfq5CdmiaoQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@fluffylabs/shared-ui/-/shared-ui-0.8.2.tgz",
+      "integrity": "sha512-kXz3zGRXMPixydEAw3zk1oUFT8DE4z26HR1u+5cuhth8MVenYsOYbcgd33Xe8Hszu37se899NriSqOXeqNJBdg==",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.3.0",
-        "jsdom": "^29.0.2",
+        "jsdom": "^29.1.0",
         "tailwindcss": "^4.2.3",
         "typescript": "^5.9.3",
         "vite": "^8.0.9",
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
-      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dev": true,
       "funding": [
         {
@@ -3400,13 +3400,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -3726,28 +3726,28 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
-      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.5",
-        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
         "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7",
-        "parse5": "^8.0.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -4206,13 +4206,13 @@
       }
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -4792,9 +4792,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@fluffylabs/shared-ui": "^0.8.1",
         "@typeberry/lib": "^0.5.10",
         "lucide-react": "^1.8.0",
-        "react": "^19.2.4",
+        "react": "^19.2.5",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.1"
       },
@@ -4313,9 +4313,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fluffylabs/shared-ui": "^0.8.1",
-        "@typeberry/lib": "^0.5.10",
+        "@typeberry/lib": "^0.5.11",
         "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2784,9 +2784,9 @@
       }
     },
     "node_modules/@typeberry/lib": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@typeberry/lib/-/lib-0.5.10.tgz",
-      "integrity": "sha512-PYISWfTXjWew9j3SA58Y/+jO8qVZqXhak+Hw01aQ3ip/q6JfK4FwA8NhSqZXLFTen7HxRQmkK+uuzApcTC9spQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@typeberry/lib/-/lib-0.5.11.tgz",
+      "integrity": "sha512-fI4M4hEE9RxJIY+NGdIg/RANJmKsEK4I0CD5/pfrnMHYYnWSf199GgA/wvFpSClshN6GqENlFUCBWubaAA1TmQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@fluffylabs/anan-as": "^1.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@typeberry/lib": "^0.5.11",
         "lucide-react": "^1.8.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.4",
+        "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
@@ -4322,15 +4322,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.14.1"
+        "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -4389,9 +4389,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
-      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4411,12 +4411,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
-      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.1"
+        "react-router": "7.14.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@fluffylabs/shared-ui": "^0.8.1",
+    "@fluffylabs/shared-ui": "^0.8.2",
     "@typeberry/lib": "^0.5.10",
     "lucide-react": "^1.8.0",
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fluffylabs/shared-ui": "^0.8.1",
     "@typeberry/lib": "^0.5.10",
     "lucide-react": "^1.8.0",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.3.0",
-    "jsdom": "^29.0.2",
+    "jsdom": "^29.1.0",
     "tailwindcss": "^4.2.3",
     "typescript": "^5.9.3",
     "vite": "^8.0.9",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.14.1"
+    "react-router-dom": "^7.14.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@fluffylabs/shared-ui": "^0.8.1",
-    "@typeberry/lib": "^0.5.10",
+    "@typeberry/lib": "^0.5.11",
     "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@typeberry/lib": "^0.5.11",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2"
   },
   "devDependencies": {

--- a/src/components/examples/objects/workPackage.ts
+++ b/src/components/examples/objects/workPackage.ts
@@ -10,10 +10,10 @@ export const workPackageExample = (
   spec: config.ChainSpec = config.tinyChainSpec,
 ): ClassInstance<typeof block.WorkPackage> =>
   block.WorkPackage.create({
-    authorization: bytesBlobFrom("authorization"),
+    authToken: bytesBlobFrom("authorization"),
     authCodeHost: block.tryAsServiceId(99),
     authCodeHash: filledHash(40),
-    parametrization: bytesBlobFrom("params"),
+    authConfiguration: bytesBlobFrom("params"),
     context: refineContextExample(spec),
     items: FixedSizeArray.new([workItemExample(spec)], block.tryAsWorkItemsCount(1)),
   });


### PR DESCRIPTION
## Summary

Combined Dependabot bumps to reduce review/CI overhead.

### Bumps included

- bumps `react` from 19.2.4 to 19.2.5 (#94)
- bumps `react-router-dom` from 7.14.1 to 7.14.2 (#93)
- bumps `@typeberry/lib` from 0.5.10 to 0.5.11 (#92)
- bumps `jsdom` from 29.0.2 to 29.1.0 (#91)
- bumps `@fluffylabs/shared-ui` from 0.8.1 to 0.8.2 (#90)

### Additional changes required

- Bumped `react-dom` to 19.2.5 to match `react` (Dependabot only opened a `react` bump, but the two must stay in sync).
- Adapted `src/components/examples/objects/workPackage.ts` to the renamed fields in `@typeberry/lib` 0.5.11: `authorization` → `authToken`, `parametrization` → `authConfiguration`.

## Test plan

- [x] `npm run qa` (biome ci) passes
- [x] `npm run build` (tsc + vite build) passes
- [x] `npm test -- --run` (154 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)